### PR TITLE
Remove end to end tests from CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,46 +18,6 @@ jobs:
         run: |
           npm ci
           npm run test
-  test_e2e:
-    name: End to End Tests
-    runs-on: ubuntu-latest
-    container: node:16.14.2-alpine3.15
-    env:
-      DB_PASS: ruv2cyHT4H78BVzK7b4DnBAHJR8dG4fG
-      DB_USER: admin
-      DB_NAME: codesupport-api
-    services:
-      postgres:
-        image: postgres:12
-        env:
-          POSTGRES_PASSWORD: $DB_PASS
-          POSTGRES_USER: $DB_USER
-          POSTGRES_DB: $DB_NAME
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-    steps:
-      - uses: actions/checkout@v2
-      - name: Runs End to End Tests
-        env:
-          DATABASE_HOST: postgres
-          DATABASE_PASS: $DB_PASS
-          DATABASE_USER: $DB_USER
-          DATABASE_NAME: $DB_NAME
-          AUTH0_ISSUER_URL: ${{ secrets.AUTH0_ISSUER_URL }}
-          AUTH0_AUDIENCE: http://localhost:8080
-          AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
-          AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
-          AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
-        run: |
-          npm ci
-          npm run migration:run
-          npm run seed:run
-          npm run test:e2e
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Since people run CI on their forks end to end tests do not run successfully, therefore blocking the merge process. For the time being, we will remove this job from CI as we investigate a better solution.
